### PR TITLE
Update .env.example to refine CORS_ALLOWED_ORIGINS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,9 @@ DB_DATABASE=my_database
 POSTGRES_CONTAINER_NAME=postgres-db
 POSTGRES_IMAGE=postgres:18.4
 
-# Must include the API origin for the chosen PORT, plus local frontends.
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174
+# Must include the API origin for the chosen PORT, plus local frontends
+# (admin Vite 5173/5174, storefront Next 3100). Credentials CORS; do not use *.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3100,http://localhost:5173,http://localhost:5174
 
 # Logging
 LOG_LEVEL=info


### PR DESCRIPTION
- Expanded CORS_ALLOWED_ORIGINS to include the storefront Next.js application on port 3100.
- Added clarification regarding the use of credentials in CORS settings, emphasizing not to use '*'.