### PR TITLE
ES-227: fix(deps): override sanitize-html htmlparser2 for Jest CJS co…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10709,7 +10709,6 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -10722,7 +10721,6 @@
     },
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "4.5.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10733,7 +10731,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10744,7 +10741,6 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -10758,7 +10754,6 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -10984,7 +10979,6 @@
     },
     "node_modules/entities": {
       "version": "7.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -12541,7 +12535,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -16641,107 +16634,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/dom-serializer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
-      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0",
-        "entities": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domelementtype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
-      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domhandler": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
-      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
-      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^3.0.0",
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/entities": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
-      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
-      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0",
-        "domutils": "^4.0.2",
-        "entities": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -212,6 +212,9 @@
   "overrides": {
     "multer": "^2.3.0",
     "qs": "^6.16.0",
+    "sanitize-html": {
+      "htmlparser2": "10.1.0"
+    },
     "js-yaml": "5.2.3",
     "@eslint/eslintrc": {
       "minimatch": {


### PR DESCRIPTION
…mpatibility

- Pin htmlparser2 to 10.1.0 under sanitize-html overrides in package.json
- Resolves Jest "Cannot use import statement outside a module" caused by pure-ESM htmlparser2@12
- Preserves sanitize-html@2.17.7 with 0 security audit vulnerabilities